### PR TITLE
Fix JSON syntax in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,22 +2,22 @@
 The package can be installed via Composer by requiring the "philo/laravel-blade": "3.*" package in your project's composer.json.
 
 ```json
-[
+{
 	"require": {
 	    "philo/laravel-blade": "3.*"
 	}
-]
+}
 ```
 
 ### Installation (Blade Laravel 4)
 The package can be installed via Composer by requiring the "philo/laravel-blade": "2.*" package in your project's composer.json.
 
 ```json
-[
+{
 	"require": {
 	    "philo/laravel-blade": "2.*"
 	}
-]
+}
 ```
 
 ### Usage


### PR DESCRIPTION
The JSON shown in the readme for including the Composer package is not valid. This merely corrects the square brackets to curly braces.