### PR TITLE
Restrict to Laravel 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         }
     ],
     "require": {
-        "illuminate/view": "~5",
-        "illuminate/events": "~5"
+        "illuminate/view": "~5.0.0",
+        "illuminate/events": "~5.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
With the introduction of 5.1, bindShared() has been replaced by singleton(). A quick fix will be to restrict the version to only pull 5.0 versions.