### PR TITLE
bindShared has been replaced with the singleton method

### DIFF
--- a/src/Blade.php
+++ b/src/Blade.php
@@ -68,13 +68,13 @@ class Blade {
 
 	public function registerFilesystem()
 	{
-		$this->container->bindShared('files', function(){
+		$this->container->singleton('files', function(){
 			return new Filesystem;
 		});
 	}
 	public function registerEvents(Dispatcher $events)
 	{
-		$this->container->bindShared('events', function() use ($events)
+		$this->container->singleton('events', function() use ($events)
 		{
 			return $events;
 		});
@@ -88,7 +88,7 @@ class Blade {
 	{
 		$me = $this;
 
-		$this->container->bindShared('view.engine.resolver', function($app) use ($me)
+		$this->container->singleton('view.engine.resolver', function($app) use ($me)
 		{
 			$resolver = new EngineResolver;
 
@@ -129,7 +129,7 @@ class Blade {
 		// The Compiler engine requires an instance of the CompilerInterface, which in
 		// this case will be the Blade compiler, so we'll first create the compiler
 		// instance to pass into the engine so it can compile the views properly.
-		$this->container->bindShared('blade.compiler', function($app) use ($me)
+		$this->container->singleton('blade.compiler', function($app) use ($me)
 		{
 			$cache = $me->cachePath;
 
@@ -150,7 +150,7 @@ class Blade {
 	public function registerViewFinder()
 	{
 		$me = $this;
-		$this->container->bindShared('view.finder', function($app) use ($me)
+		$this->container->singleton('view.finder', function($app) use ($me)
 		{
 			$paths = $me->viewPaths;
 


### PR DESCRIPTION
The service container's `bindShared` method has been deprecated in favor of the `singleton` method.