### PR TITLE
Correct PHPDoc return type

### DIFF
--- a/src/Blade.php
+++ b/src/Blade.php
@@ -161,7 +161,7 @@ class Blade {
 	/**
 	 * Register the view environment.
 	 *
-	 * @return void
+	 * @return Factory
 	 */
 	public function registerFactory()
 	{


### PR DESCRIPTION
Unlike upstream function, this does not return void but Factory type. Makes IDE happy.